### PR TITLE
Replace verbose error message with status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The module defines 1 output, "air_carbon_dioxide" on which reading is sent once 
 
 Current implementation is hardcoded to read sensor values from Arduino Mega2560 Serial2 interface.
 
+# Status Codes
+
+- "31": CRC error
+
 # Todo
 1. Add arguments to configure interface type (Serial or PWM) and pins the sensor is attached to.
 

--- a/openag_mhz19.cpp
+++ b/openag_mhz19.cpp
@@ -60,8 +60,7 @@ void Mhz19::readData() {
   crc++;
   if ( !(response[0] == 0xFF && response[1] == 0x86 && response[8] == crc) ) {
     status_level = ERROR;
-    status_msg = "CRC error " + String(crc) + " / "+ String(response[8]) + " => ";
-    for (i = 0; i< 9; i++) status_msg = status_msg + String(response[i], HEX) + ",";
+    status_msg = "31";
   } else {
     unsigned int responseHigh = (unsigned int) response[2];
     unsigned int responseLow = (unsigned int) response[3];


### PR DESCRIPTION
This is a short-term fix for status message buffer overflow that simply reduces
the number of bits.